### PR TITLE
WIP: Add Python 3 support

### DIFF
--- a/demo/demo_awtonly.py
+++ b/demo/demo_awtonly.py
@@ -11,6 +11,8 @@ All rights reserved.
 
 """
 
+from __future__ import absolute_import
+
 import os
 import wx
 import javabridge

--- a/demo/demo_nogui.py
+++ b/demo/demo_nogui.py
@@ -11,12 +11,16 @@ All rights reserved.
 
 """
 
+from __future__ import print_function
+
+from __future__ import absolute_import
+
 import os
 import javabridge
 
 javabridge.start_vm(run_headless=True)
 try:
-    print javabridge.run_script('java.lang.String.format("Hello, %s!", greetee);', 
-                                dict(greetee='world'))
+    print(javabridge.run_script('java.lang.String.format("Hello, %s!", greetee);', 
+                                dict(greetee='world')))
 finally:
     javabridge.kill_vm()

--- a/demo/demo_uicallback.py
+++ b/demo/demo_uicallback.py
@@ -28,6 +28,8 @@ Copyright (c) 2009-2013 Broad Institute
 All rights reserved.
 
 """
+
+from __future__ import absolute_import
 import javabridge
 import sys
 import traceback

--- a/demo/demo_wxandawt.py
+++ b/demo/demo_wxandawt.py
@@ -11,6 +11,8 @@ All rights reserved.
 
 """
 
+from __future__ import absolute_import
+
 import os
 import wx
 import javabridge

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+
+from __future__ import absolute_import
 import sys, os
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/javabridge/__init__.py
+++ b/javabridge/__init__.py
@@ -9,10 +9,12 @@ All rights reserved.
 
 """
 
+from __future__ import absolute_import
+
 import os.path
 
 try:
-    from _version import __version__
+    from ._version import __version__
 except ImportError:
     # We're running in a tree that doesn't have a _version.py, so we don't know what our version is.
     __version__ = "0.0.0"

--- a/javabridge/jutil.py
+++ b/javabridge/jutil.py
@@ -10,6 +10,10 @@ All rights reserved.
 
 '''
 
+from __future__ import print_function
+
+from __future__ import absolute_import
+
 import codecs
 import gc
 import inspect
@@ -336,7 +340,7 @@ def run_script(script, bindings_in = {}, bindings_out = {},
         scope = make_instance("org/mozilla/javascript/ImporterTopLevel",
                               "(Lorg/mozilla/javascript/Context;)V",
                               context)
-        for k, v in bindings_in.iteritems():
+        for k, v in bindings_in.items():
             call(scope, "put", 
                  "(Ljava/lang/String;Lorg/mozilla/javascript/Scriptable;"
                  "Ljava/lang/Object;)V", k, scope, v)
@@ -355,7 +359,7 @@ def run_script(script, bindings_in = {}, bindings_out = {},
                 "(Ljava/lang/String;"
                 "Lorg/mozilla/javascript/Scriptable;)"
                 "Ljava/lang/Object;", k, scope))
-    except JavaException, e:
+    except JavaException as e:
         if is_instance_of(e.throwable, "org/mozilla/javascript/WrappedException"):
             raise JavaException(call(e.throwable, "unwrap", "()Ljava/lang/Object;"))
         else:
@@ -632,7 +636,7 @@ def run_in_main_thread(closure, synchronous):
         def synchronous_closure():
             try:
                 result[0] = closure()
-            except Exception, e:
+            except Exception as e:
                 logger.exception("Caught exception when executing closure")
                 exception[0] = e
             done_event.set()
@@ -655,7 +659,7 @@ def print_all_stack_traces():
     for stak in stal:
         stakes = get_env().get_object_array_elements(stak)
         for stake in stakes:
-            print to_string(stake)
+            print(to_string(stake))
             
 CLOSE_ALL_WINDOWS = """
         new java.lang.Runnable() { 
@@ -1558,7 +1562,7 @@ def make_map(**kwargs):
         public java.lang.Object java.util.HashMap.put(java.lang.Object,java.lang.Object)
     '''
     hashmap = get_map_wrapper(make_instance('java/util/HashMap', "()V"))
-    for k, v in kwargs.iteritems():
+    for k, v in kwargs.items():
         hashmap[k] = v
     return hashmap
 
@@ -1578,7 +1582,7 @@ def jdictionary_to_string_dictionary(hashtable):
 
     '''
     jhashtable = get_dictionary_wrapper(hashtable)
-    jkeys = jhashtable.keys()
+    jkeys = list(jhashtable.keys())
     keys = jenumeration_to_string_list(jkeys)
     result = {}
     for key in keys:
@@ -2025,7 +2029,7 @@ def make_run_dictionary(jobject_address):
     d = get_dictionary_wrapper(jmap)
     
     result = {}
-    keys = jenumeration_to_string_list(d.keys())
+    keys = jenumeration_to_string_list(list(d.keys()))
     for key in keys:
         result[key] = d.get(key)
     return result

--- a/javabridge/locate.py
+++ b/javabridge/locate.py
@@ -9,6 +9,8 @@ All rights reserved.lo
 
 """
 
+from __future__ import absolute_import
+
 import os
 import sys
 import logging
@@ -34,11 +36,11 @@ def find_javahome():
             jvm_path = os.path.join(path, "bin", jvm_folder, "jvm.dll")
             if os.path.exists(jvm_path):
                 # Problem: have seen JAVA_HOME != jvm_path cause DLL load problems
-                if os.environ.has_key("JAVA_HOME"):
+                if "JAVA_HOME" in os.environ:
                     del os.environ["JAVA_HOME"]
                 return path
     
-    if os.environ.has_key('JAVA_HOME'):
+    if 'JAVA_HOME' in os.environ:
         return os.environ['JAVA_HOME']
     elif is_mac:
         return "Doesn't matter"

--- a/javabridge/noseplugin.py
+++ b/javabridge/noseplugin.py
@@ -9,6 +9,8 @@ All rights reserved.
 
 """
 
+from __future__ import absolute_import
+
 import logging
 from nose.plugins import Plugin
 import os

--- a/javabridge/tests/test_javabridge.py
+++ b/javabridge/tests/test_javabridge.py
@@ -9,6 +9,8 @@ All rights reserved.
 
 '''
 
+from __future__ import absolute_import
+
 __version__="$Revision$"
 
 import os
@@ -445,7 +447,7 @@ class TestJavabridge(unittest.TestCase):
         klass = self.env.find_class("java/security/Key")
         field_id = self.env.get_static_field_id(klass, "serialVersionUID", "J")
         result = self.env.get_static_long_field(klass, field_id)
-        self.assertEqual(result, 6603384152749567654l) # see http://java.sun.com/j2se/1.4.2/docs/api/constant-values.html#java.security.Key.serialVersionUID
+        self.assertEqual(result, 6603384152749567654) # see http://java.sun.com/j2se/1.4.2/docs/api/constant-values.html#java.security.Key.serialVersionUID
     
     def test_05_07_get_static_float_field(self):
         klass = self.env.find_class("java/lang/Float")

--- a/javabridge/tests/test_jutil.py
+++ b/javabridge/tests/test_jutil.py
@@ -9,6 +9,8 @@ All rights reserved.
 
 '''
 
+from __future__ import absolute_import
+
 __version__="$Revision$"
 
 import gc
@@ -89,7 +91,7 @@ class TestJutil(unittest.TestCase):
         d = javabridge.get_dictionary_wrapper(properties)
         self.assertTrue(d.size() > 10)
         self.assertFalse(d.isEmpty())
-        keys = javabridge.get_enumeration_wrapper(d.keys())
+        keys = javabridge.get_enumeration_wrapper(list(d.keys()))
         values = javabridge.get_enumeration_wrapper(d.elements())
         n_elems = d.size()
         for i in range(n_elems):
@@ -105,8 +107,8 @@ class TestJutil(unittest.TestCase):
         properties = javabridge.static_call("java/lang/System", "getProperties",
                                    "()Ljava/util/Properties;")
         d = javabridge.get_dictionary_wrapper(properties)
-        keys = javabridge.jenumeration_to_string_list(d.keys())
-        enum = javabridge.get_enumeration_wrapper(d.keys())
+        keys = javabridge.jenumeration_to_string_list(list(d.keys()))
+        enum = javabridge.get_enumeration_wrapper(list(d.keys()))
         for i in range(d.size()):
             key = javabridge.to_string(enum.nextElement())
             self.assertEqual(key, keys[i])
@@ -116,7 +118,7 @@ class TestJutil(unittest.TestCase):
                                    "()Ljava/util/Properties;")
         d = javabridge.get_dictionary_wrapper(properties)
         pyd = javabridge.jdictionary_to_string_dictionary(properties)
-        keys = javabridge.jenumeration_to_string_list(d.keys())
+        keys = javabridge.jenumeration_to_string_list(list(d.keys()))
         for key in keys:
             value = javabridge.to_string(d.get(key))
             self.assertEqual(pyd[key], value)
@@ -529,7 +531,7 @@ class TestJutil(unittest.TestCase):
         # Regression test of issue #11: the expression below segfaulted
         #
         def fn():
-            list(javabridge.iterate_java(javabridge.make_list(range(10)).o))
+            list(javabridge.iterate_java(javabridge.make_list(list(range(10))).o))
         self.assertRaises(javabridge.JavaError, fn)
 
     def test_10_01_class_path(self):

--- a/javabridge/tests/test_wrappers.py
+++ b/javabridge/tests/test_wrappers.py
@@ -8,6 +8,8 @@ Copyright (c) 2009-2013 Broad Institute
 All rights reserved.
 
 '''
+
+from __future__ import absolute_import
 import unittest
 import javabridge as J
 

--- a/javabridge/wrappers.py
+++ b/javabridge/wrappers.py
@@ -10,6 +10,8 @@ All rights reserved.
 
 '''
 
+from __future__ import absolute_import
+
 import numpy as np
 import sys
 import javabridge as J

--- a/jenkins/docker/centos_javabridge_build/get-pip.py
+++ b/jenkins/docker/centos_javabridge_build/get-pip.py
@@ -19,6 +19,8 @@
 # If you're wondering how this is created, the secret is
 # "contrib/build-installer" from the pip repository.
 
+
+from __future__ import absolute_import
 ZIPFILE = b"""
 UEsDBBQAAAAIAPw4PESuKzUKeAwAAOokAAAPAAAAcGlwL19faW5pdF9fLnB5pRprb+M28rt/BTdp
 IKlrq00PxQHBuejdNosu0HaD7O71gKwhyBJts5FFlZSceNv+95sZkiJlKWkPp0VjSeQ8OO8Z9fzF

--- a/setup.py
+++ b/setup.py
@@ -181,8 +181,9 @@ def get_version():
     if os.path.exists(os.path.join(os.path.dirname(__file__), '.git')):
         import subprocess
         try:
-            git_version = subprocess.Popen(['git', 'describe'], 
-                                           stdout=subprocess.PIPE).communicate()[0].strip()
+            git_version = str(subprocess.Popen(['git', 'describe'], 
+                              stdout=subprocess.PIPE).communicate()[0].strip())
+            git_version = git_version.lstrip("b'").rstrip("'")
         except:
             pass
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,10 @@ All rights reserved.
 
 """
 
+from __future__ import print_function
+
+from __future__ import absolute_import
+
 import errno
 import glob
 import os
@@ -42,7 +46,7 @@ def build_cython():
     pyx_filenames = [in_cwd(s + '.pyx') for s in stems]
     if any(map(os.path.exists, pyx_filenames)):
         cmd = ['cython'] + pyx_filenames
-        print ' '.join(cmd)
+        print(' '.join(cmd))
         subprocess.check_call(cmd)
 
 def ext_modules():
@@ -52,7 +56,7 @@ def ext_modules():
     if java_home is None:
         raise JVMNotFoundError()
     jdk_home = find_jdk()
-    print "Using jdk_home =", jdk_home
+    print("Using jdk_home =", jdk_home)
     include_dirs = [get_include()]
     libraries = None
     library_dirs = None
@@ -116,7 +120,7 @@ def ext_modules():
 def needs_compilation(target, *sources):
     try:
         target_date = os.path.getmtime(target)
-    except OSError, e:
+    except OSError as e:
         if e.errno != errno.ENOENT:
             raise
         return True
@@ -133,14 +137,14 @@ def build_jar_from_single_source(jar, source):
     if needs_compilation(jar, source):
         javac_loc = find_javac_cmd()
         javac_command = [javac_loc, package_path(source)]
-        print ' '.join(javac_command)
+        print(' '.join(javac_command))
         subprocess.check_call(javac_command)
         if not os.path.exists(os.path.dirname(jar)):
             os.mkdir(os.path.dirname(jar))
         jar_command = [find_jar_cmd(), 'cf', package_path(jar)]
         for klass in glob.glob(source[:source.rindex('.')] + '*.class'):
             jar_command.extend(['-C', package_path('java'), klass[klass.index('/') + 1:]])
-        print ' '.join(jar_command)
+        print(' '.join(jar_command))
         subprocess.check_call(jar_command)
 
 def build_runnablequeue():
@@ -154,7 +158,7 @@ def build_test():
     build_jar_from_single_source(jar, source)
 
 def build_java():
-    print "running build_java"
+    print("running build_java")
     build_runnablequeue()
     build_test()
 
@@ -198,7 +202,7 @@ def get_version():
 
     if git_version and git_version != cached_version:
         with open(version_file, 'w') as f:
-            print >>f, '__version__ = "%s"' % git_version
+            print('__version__ = "%s"' % git_version, file=f)
 
     return git_version or cached_version
 


### PR DESCRIPTION
I'm in the process of upgrading the source code to support Python 3. As of this PR all pure Python is ported, but running into some Cython/Java compilation issues:

```
copying javabridge/jars/rhino-1.7R4.jar -> build/lib.macosx-10.5-x86_64-3.4/javabridge/jars
running build_ext
running build_java
javac java/org/cellprofiler/runnablequeue/RunnableQueue.java
jar cf javabridge/jars/runnablequeue.jar -C java org/cellprofiler/runnablequeue/RunnableQueue$1.class -C java org/cellprofiler/runnablequeue/RunnableQueue.class
javac java/org/cellprofiler/javabridge/test/RealRect.java
jar cf javabridge/jars/test.jar -C java org/cellprofiler/javabridge/test/RealRect.class
cython _javabridge.pyx _javabridge_mac.pyx _javabridge_nomac.pyx

Error compiling Cython file:
------------------------------------------------------------
...
                bresult = jnienv[0].CallByteMethodA(jnienv, this, m_id, values)
            result = bresult
        elif sig == 'C':
            with nogil:
                cresult = jnienv[0].CallCharMethodA(jnienv, this, m_id, values)
            result = unichr(cresult)
                          ^
------------------------------------------------------------

_javabridge.pyx:831:27: undeclared name not builtin: unichr
```