### PR TITLE
On Linux, make sure to load the native Python library globally

### DIFF
--- a/java/org_cellprofiler_javabridge_CPython.c
+++ b/java/org_cellprofiler_javabridge_CPython.c
@@ -10,9 +10,24 @@ All rights reserved.
 #include <jni.h>
 #include <stdio.h>
 #include <Python.h>
+#include <dlfcn.h>
 #include "org_cellprofiler_javabridge_CPython.h"
 
 int initialized = 0;
+
+#ifdef __linux__
+/*
+ * On Linux, it appears that Python's symbols cannot be found by other
+ * native libraries if we let the JVM load libpython... so we have to load it
+ * explicitly, with the correct flag (RTLD_GLOBAL).
+ */
+
+jint JNI_OnLoad(JavaVM *vm, void *reserved)
+{
+	dlopen("/usr/lib/x86_64-linux-gnu/libpython2.7.so", RTLD_LAZY | RTLD_GLOBAL);
+	return JNI_VERSION_1_2;
+}
+#endif
 
 #ifdef _WIN32
 /*


### PR DESCRIPTION
On Linux, we must ensure that the native Python library is loaded with global scope so that e.g. NumPy's native part can access the symbols.

The caller can specify the location of the native Python library by setting the `python.location` property; if unset, we will use Debian's/Ubuntu's standard location by default. 