### PR TITLE
Add 'with javabridge.vm()' statement

### DIFF
--- a/demo/demo_nogui_with_stmt.py
+++ b/demo/demo_nogui_with_stmt.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+"""demo_nogui.py - show how to start the Javabridge without a GUI
+
+python-javabridge is licensed under the BSD license.  See the
+accompanying file LICENSE for details.
+
+Copyright (c) 2003-2009 Massachusetts Institute of Technology
+Copyright (c) 2009-2013 Broad Institute
+All rights reserved.
+
+"""
+
+import os
+import javabridge
+
+with javabridge.vm(run_headless=True):
+    print javabridge.run_script('java.lang.String.format("Hello, %s!", greetee);', 
+                                dict(greetee='world'))

--- a/docs/hello.rst
+++ b/docs/hello.rst
@@ -12,7 +12,16 @@ Without a GUI::
                                     dict(greetee='world'))
     finally:
         javabridge.kill_vm()
+
+You can also use a with block::
+
+    import os
+    import javabridge
     
+    with javabridge.vm(run_headless=True)
+        print javabridge.run_script('java.lang.String.format("Hello, %s!", greetee);',
+                                    dict(greetee='world'))
+
 With only a Java AWT GUI::
 
     import os

--- a/javabridge/__init__.py
+++ b/javabridge/__init__.py
@@ -25,7 +25,7 @@ JARS = [os.path.realpath(os.path.join(_jars_dir, name + '.jar'))
         for name in ['rhino-1.7R4', 'runnablequeue', 'cpython']]
 
 
-from .jutil import start_vm, kill_vm, activate_awt, deactivate_awt
+from .jutil import start_vm, kill_vm, vm, activate_awt, deactivate_awt
 
 from .jutil import attach, detach, get_env
 

--- a/javabridge/jutil.py
+++ b/javabridge/jutil.py
@@ -170,6 +170,17 @@ class AtExit(object):
         
 __start_thread = None        
 
+class vm():
+    def __init__(self, *args, **kwds):
+	self.args = args
+	self.kwds = kwds
+
+    def __enter__(self):
+        start_vm(*self.args, **self.kwds)
+
+    def __exit__(self, type, value, traceback):
+        kill_vm()
+
 def start_vm(args=None, class_path=None, max_heap_size=None, run_headless=False):
     '''Start the Java Virtual Machine.
 


### PR DESCRIPTION
This adds javabridge.vm() which makes the usage of javabridge more 'pythonic' by using the `with` statement:

    with javabridge.vm(run_headless=True):
      print javabridge.run_script('java.lang.String.format("Hello, %s!", greetee);', 

(Not being able to use `with` has been bugging me for a while ;)