### PR TITLE
Fixes #75 + test. Need explicit handling for utf-encoded Python 2.7 strings

### DIFF
--- a/javabridge/jutil.py
+++ b/javabridge/jutil.py
@@ -1171,7 +1171,9 @@ def get_nice_arg(arg, sig):
         if arg is None:
             return None
         else:
-            arg = unicode(arg)
+            if sys.version_info.major == 2:
+                if isinstance(arg, str):
+                    arg = arg.decode("utf-8")
         return env.new_string_utf(arg)
     if sig == 'Ljava/lang/Integer;' and type(arg) in [int, long, bool]:
         return make_instance('java/lang/Integer', '(I)V', int(arg))

--- a/javabridge/tests/test_jutil.py
+++ b/javabridge/tests/test_jutil.py
@@ -662,5 +662,17 @@ class TestJutil(unittest.TestCase):
         javabridge.unlock_jref(ref_self)
         self.assertRaises(KeyError, javabridge.redeem_jref, ref_self)
         
+    def test_13_01_unicode_arg(self):
+        # On 2.x, check that a unicode argument is properly prepared
+        s = u"Hola ni\u00F1os"
+        s1, s2 = s.split(" ")
+        if sys.version_info.major == 2:
+            s2 = s2.encode("utf-8")
+        env = javabridge.get_env()
+        js1 = env.new_string(s1+" ")
+        result = javabridge.call(
+            js1, "concat", "(Ljava/lang/String;)Ljava/lang/String;", s2)
+        self.assertEqual(s, result)
+        
 if __name__=="__main__":
     unittest.main()


### PR DESCRIPTION
Tests fail in CellProfiler because of this.