### PR TITLE
Fix DLL imports for Python 3.8

### DIFF
--- a/javabridge/jutil.py
+++ b/javabridge/jutil.py
@@ -149,6 +149,11 @@ if sys.platform == "win32":
     #
     os.environ["PATH"] = os.environ["PATH"] + os.pathsep + _find_jvm() + \
        os.pathsep + os.path.join(find_javahome(), "bin")
+    try:
+        os.add_dll_directory(_find_jvm())
+        os.add_dll_directory(os.path.join(find_javahome(), "bin"))
+    except AttributeError:
+        logger.debug("DLL directories not added to environment, may cause problems in Python 3.8+")
     
 elif sys.platform == "darwin":
     # Has side-effect of preloading dylibs


### PR DESCRIPTION
As of Python 3.8, Windows will no longer search for .dll/.pyd files in PATH as per the link below. This was causing javabridge to struggle to import some essential files.

https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew

To solve this I've used the new os.add_dll_directory() function, which seems to fix the problems identified in LeeKamentsky/python-javabridge#177 and LeeKamentsky/python-javabridge#178. As this doesn't exist in 3.7 I've left the old functionality intact (in 3.8 it does nothing), as I'm not sure if this older python versions are still being supported.