### PR TITLE
More robust Java hunting

### DIFF
--- a/javabridge/locate.py
+++ b/javabridge/locate.py
@@ -70,6 +70,16 @@ logger = logging.getLogger(__name__)
 
 def find_javahome():
     """Find JAVA_HOME if it doesn't exist"""
+    if is_win and hasattr(sys, "frozen"):
+        # If we're frozen we probably have a packaged java environment.
+        if 'CP_JAVA_HOME' in os.environ:
+            app_path = os.path.dirname(sys.executable)
+            java_path = os.path.join(app_path, 'java')
+            if os.path.exists(java_path):
+                return java_path
+        else:
+            # Allow user to override java install by unsetting CP_JAVA_HOME, for whatever reason.
+            print("CP_JAVA_HOME registry key not found, searching for java elsewhere.")
     if 'CP_JAVA_HOME' in os.environ:
         # Prefer CellProfiler's JAVA_HOME if it's set.
         return os.environ['CP_JAVA_HOME']
@@ -161,7 +171,14 @@ def find_javahome():
                     continue
                 else:
                     raise
-
+        if hasattr(sys, "frozen"):
+            print(
+                "CellProfiler Startup ERROR: Could not find path to Java environment directory.\n"
+                "Please set the CP_JAVA_HOME system environment variable.\n"
+                "Visit http://broad.io/cpjava for instructions."
+            )
+            os.system("pause")  # Keep console window open until keypress.
+            os._exit(1)
         raise RuntimeError(
             "Failed to find the Java Runtime Environment. "
             "Please download and install the Oracle JRE 1.6 or later"


### PR DESCRIPTION
Added code for frozen Windows versions. If CP_JAVA_HOME is set and we're on a frozen build, we first check whether there's a java directory in the cellprofiler.exe folder and use it if it's there. Failing that we use whatever the key specifies. The user can unset the CP_JAVA_HOME key to use JAVA_HOME or JDK instead.

This is based around the issue that a user might install CP3, then CP4, then uninstall CP3. This would leave an incorrect CP_JAVA_HOME key pointing to the wrong folder. This should also be more compatible with running multiple versions of CellProfiler.