### PR TITLE
Further refine java detection on Windows

### DIFF
--- a/javabridge/locate.py
+++ b/javabridge/locate.py
@@ -72,14 +72,13 @@ def find_javahome():
     """Find JAVA_HOME if it doesn't exist"""
     if is_win and hasattr(sys, "frozen"):
         # If we're frozen we probably have a packaged java environment.
-        if 'CP_JAVA_HOME' in os.environ:
-            app_path = os.path.dirname(sys.executable)
-            java_path = os.path.join(app_path, 'java')
-            if os.path.exists(java_path):
-                return java_path
+        app_path = os.path.dirname(sys.executable)
+        java_path = os.path.join(app_path, 'java')
+        if os.path.exists(java_path):
+            return java_path
         else:
-            # Allow user to override java install by unsetting CP_JAVA_HOME, for whatever reason.
-            print("CP_JAVA_HOME registry key not found, searching for java elsewhere.")
+            # Can use env from CP_JAVA_HOME or JAVA_HOME by removing the CellProfiler/java folder.
+            print("Packaged java environment not found, searching for java elsewhere.")
     if 'CP_JAVA_HOME' in os.environ:
         # Prefer CellProfiler's JAVA_HOME if it's set.
         return os.environ['CP_JAVA_HOME']


### PR DESCRIPTION
Following discussion in cellprofiler/cellprofiler#4320, I figure that this is a better approach to finding a Java installation.

Currently frozen versions of CP check for a `CP_JAVA_HOME` environment variable, if that's present at all then we search for java in the CP installation folder. If there's no java environment there we look for java in the directory `CP_JAVA_HOME` references. This was intended to allow the user to switch to a different java environment by unsetting the `CP_JAVA_HOME` key, so hat `JAVA_HOME` is then used. They key problem is that older CP versions use the same key to point to their own java folders, and the key is only created for the Windows user that installed CellProfiler, not all users.

This new solution first checks for the java folder in the CP directory. If it's not present we then check for `CP_JAVA_HOME`, then `JAVA_HOME`, then other possible locations. A user can switch java environment by removing or renaming the packaged java folder. This also removes the need to set the `CP_JAVA_HOME` key on Windows during installation (thus eliminating the user vs system scope issue too).