### PR TITLE
Make find_javahome() work with OpenJDK 11 on Ubuntu 20.04

### DIFF
--- a/javabridge/locate.py
+++ b/javabridge/locate.py
@@ -132,9 +132,7 @@ def find_javahome():
         java_bin = get_out(["bash", "-c", "type -p java"])
         java_dir = get_out(["readlink", "-f", java_bin])
         java_version_string = get_out(["bash", "-c", "java -version"])
-        if re.search('^openjdk', java_version_string, re.MULTILINE) is not None:
-            jdk_dir = os.path.join(java_dir, "..", "..", "..")
-        elif re.search('^java', java_version_string, re.MULTILINE) is not None:
+        if re.search('^(openjdk|java)', java_version_string, re.MULTILINE) is not None:
             jdk_dir = os.path.join(java_dir, "..", "..")
         else:
             raise RuntimeError(


### PR DESCRIPTION
On Ubuntu 20.04 the `find_javahome()` function doesn't work as expected as it is cutting away too much of the path.

To make it work, I had to use the same line that is already there for Oracle's Java distribution.

Context:

```bash
dpkg --get-selections | grep -i openjdk-11
```

```
openjdk-11-jdk-headless:amd64			install
openjdk-11-jre:amd64				install
openjdk-11-jre-headless:amd64			install
```

And
```bash
lsb_release -a
```

```
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.2 LTS
Release:	20.04
Codename:	focal
```