### PR TITLE
Reintroduce fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,8 +97,7 @@ def ext_modules():
     if java_home is None:
         raise Exception("JVM not found")
     jdk_home = find_jdk()
-    from numpy import get_include
-    include_dirs = [get_include()] + get_jvm_include_dirs()
+    include_dirs = get_jvm_include_dirs()
     libraries = None
     library_dirs = None
     javabridge_sources = ['_javabridge.c']


### PR DESCRIPTION
This re-introduces part of https://github.com/CellProfiler/python-javabridge/commit/e9fe3dc8e62d03521786facbdba9ba2587d3dda5 which avoids using numpy before installing it as dependency. The original fix seems to have been accidentally removed by https://github.com/CellProfiler/python-javabridge/commit/7cd83b78d12cab30abecd9e58294b4cb61c42081

With this patch I can install `python-javabridge` without first installing `setuptools`.