### PR TITLE
Initial support for PEP 621

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+
+[project]
+name="python-javabridge"
+version="4.0.3"
+readme = "README.rst"
+requires-python = ">=3.8"
+description="Python wrapper for the Java Native Interface"
+classifiers=['Development Status :: 5 - Production/Stable',
+             'License :: OSI Approved :: BSD License',
+             'Programming Language :: Java',
+             'Programming Language :: Python :: 2',
+             'Programming Language :: Python :: 3'
+             ]
+dependencies = ['Cython>=0.29.16', 'numpy>=1.20.1' ]
+license={text = "BSD 3-Clause License"}

--- a/setup.py
+++ b/setup.py
@@ -97,8 +97,7 @@ def ext_modules():
     if java_home is None:
         raise Exception("JVM not found")
     jdk_home = find_jdk()
-    from numpy import get_include
-    include_dirs = [get_include()] + get_jvm_include_dirs()
+    include_dirs = get_jvm_include_dirs()
     libraries = None
     library_dirs = None
     javabridge_sources = ['_javabridge.c']


### PR DESCRIPTION
This extends https://github.com/CellProfiler/python-javabridge/pull/17 by adding (trivial) support for PEP 621. This should make it simpler to install `python-javabridge` - see e.g. https://github.com/CellProfiler/python-javabridge/issues/11