### PR TITLE
Unpin numpy

### DIFF
--- a/_javabridge.pyx
+++ b/_javabridge.pyx
@@ -1722,7 +1722,7 @@ cdef class JB_Env:
         result = np.zeros(shape=(alen,),dtype=np.uint8)
         data = result.data
         self.env[0].GetBooleanArrayRegion(self.env, array.o, 0, alen, <jboolean *>data)
-        return result.astype(np.bool8)
+        return result.astype(np.bool_)
         
     def get_byte_array_elements(self, JB_Object array):
         '''Return the contents of a Java byte array as a numpy array
@@ -1841,7 +1841,7 @@ cdef class JB_Env:
     def make_boolean_array(self, array):
         '''Create a java boolean [] array from the contents of a numpy array'''
         cdef:
-            np.ndarray[dtype=np.uint8_t, ndim=1, negative_indices=False, mode='c'] barray = array.astype(np.bool8).astype(np.uint8)
+            np.ndarray[dtype=np.uint8_t, ndim=1, negative_indices=False, mode='c'] barray = array.astype(np.bool_).astype(np.uint8)
             jobject o
             jsize alen = barray.shape[0]
             jboolean *data = <jboolean *>(barray.data)

--- a/javabridge/jutil.py
+++ b/javabridge/jutil.py
@@ -1191,7 +1191,7 @@ def get_nice_arg(arg, sig):
     
     if isinstance(arg, np.ndarray):
         if sig == '[Z':
-            return env.make_boolean_array(np.ascontiguousarray(arg.flatten(), np.bool8))
+            return env.make_boolean_array(np.ascontiguousarray(arg.flatten(), np.bool_))
         elif sig == '[B':
             return env.make_byte_array(np.ascontiguousarray(arg.flatten(), np.uint8))
         elif sig == '[S':

--- a/javabridge/tests/test_javabridge.py
+++ b/javabridge/tests/test_javabridge.py
@@ -338,7 +338,7 @@ class TestJavabridge(unittest.TestCase):
         result = self.env.call_method(jstring, method_id)
         self.assertTrue(isinstance(result, jb.JB_Object))
         a = self.env.get_byte_array_elements(result)
-        self.assertEqual(np.array(s, "S%d" % len(s)).tostring(), a.tostring())
+        self.assertEqual(np.array(s, "S%d" % len(s)).tobytes(), a.tobytes())
     
     def test_03_10_call_method_object(self):
         hello = self.env.new_string_utf("Hello, ")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "cython<3", "numpy>=1.24.0,<2"]
+requires = ["setuptools", "cython", "numpy>=1.24.0"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -398,11 +398,11 @@ cell image analysis software CellProfiler (cellprofiler.org).''',
                        ],
           license='BSD License',
           setup_requires=[
-          'Cython>=0.29.16,<3',
-          'numpy<2',
+          'Cython>=0.29.16',
+          'numpy',
          ],
           install_requires=[
-          'numpy>=1.20.1,<2',
+          'numpy>=1.20.1',
           ],
           tests_require="nose",
           entry_points={'nose.plugins.0.10': [


### PR DESCRIPTION
Closes #30.

I've tried to go for minimal changes and have ignored optimisations that I technically *should* do. Thus, I've only fixed:

* `ndarray.tostring` replaced with `ndarray.tobytes` ([Removed in 2.3](https://numpy.org/doc/stable/release/2.3.0-notes.html#expired-deprecations))
* `np.bool8` replaced with `np.bool_` ([Removed in 2.0](https://numpy.org/devdocs/release/2.0.0-notes.html#numpy-2-0-python-api-removals))

I tested that this compiles and that the tests pass. I can't get nose running, but I used this test runner to do so via `unittest`:

<details>

```python
import unittest
from pathlib import Path

import javabridge

javabridge.start_vm(class_path=[str(Path(__file__).parent / "javabridge" / "jars" / "test.jar"), *javabridge.JARS], run_headless=True)

try:
    suite = unittest.TestLoader().discover("javabridge/tests")
    unittest.TextTestRunner(verbosity=2).run(suite)
finally:
    javabridge.kill_vm()
```
</details>